### PR TITLE
Increase length of `mapper` field

### DIFF
--- a/Zones/REPLACE_ALL_maptier.sql
+++ b/Zones/REPLACE_ALL_maptier.sql
@@ -6,7 +6,7 @@ CREATE TABLE `ck_maptier` (
   `announcerecord` int(11) NOT NULL DEFAULT '0',
   `gravityfix` int(11) NOT NULL DEFAULT '1',
   `ranked` int(11) NOT NULL DEFAULT '1',
-  `mapper` varchar(32) DEFAULT 'N/A'
+  `mapper` varchar(64) DEFAULT 'N/A'
 ) DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO `ck_maptier` (`mapname`, `tier`, `maxvelocity`, `announcerecord`, `gravityfix`, `ranked`, `mapper`) VALUES


### PR DESCRIPTION
Found that while trying to import this file into my DB it failed out saying that some values (such as "Waffleburger, Knife, & Icecreamlock") were too long for the field. I've made a change that gives it a bit more room and hence fixes it.

Thanks so much for your project, its been very useful for my server otherwise.